### PR TITLE
Update OptionChecks.nsh

### DIFF
--- a/NSIS/FusionInventory-Agent/Include/OptionChecks.nsh
+++ b/NSIS/FusionInventory-Agent/Include/OptionChecks.nsh
@@ -90,7 +90,7 @@ Function IsValidOptionCollectTimeoutValue
 
    ; Check
    ${If} $R0 < 0
-   ${OrIf} $R0 > 600
+   ${OrIf} $R0 > 3600
    ${OrIfNot} ${IsAnIntegerNumber} "$R0"
       ; $R0 is an invalid value
       StrCpy $R1 1


### PR DESCRIPTION
Hi,
In some machines we have issues like this
fusioninventory/fusioninventory-agent#398 (Timeout on searching WMI), where we need to increase backend-collect-timeout parameter value. (In some cases, we need to set this value to 3600.)